### PR TITLE
Improve prompt: git branch icon and distinct green branch colour

### DIFF
--- a/cli/starship.toml
+++ b/cli/starship.toml
@@ -55,8 +55,8 @@ truncation_symbol = "⋯/"
 
 [git_branch]
 style = "fg:250 bg:236"
-symbol = " "
-format = "[ $symbol$branch ]($style)[](fg:236)"
+symbol = " "
+format = "[ $symbol]($style)[$branch ](fg:114 bg:236)[](fg:236)"
 
 [status]
 disabled = false


### PR DESCRIPTION
## Summary
- Update the starship `git_branch` module to use a git branch icon and render the branch name in a distinct green (`fg:114`), separate from the module label styling.

## Test plan
- Reload the shell and confirm the prompt shows the branch icon with the branch name in green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)